### PR TITLE
Added feature ShieldStrength

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -608,6 +608,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _speed: 3.5
   _speedMultipler: 2
+  _increasedRate: 5
   _laserPrefab: {fileID: 2160947177947254534, guid: 15e051aba15ea439a94d52d8b26ae8c2,
     type: 3}
   _tripleShotPrefab: {fileID: 2798725636558176189, guid: 496efe6af46bd41a692387b8dd0a76ff,

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -13,6 +13,8 @@ public class Player : MonoBehaviour
     [SerializeField]
     private float _increasedRate = 5.0f;
 
+    private int _shieldStrength;
+
     [SerializeField]
     private GameObject _laserPrefab;
     [SerializeField]
@@ -167,11 +169,28 @@ public class Player : MonoBehaviour
     {
         if (_isShieldPowerUpActive)
         {
-            _isShieldPowerUpActive = false;
-            _ShieldVisualer.SetActive(false);
+            _shieldStrength--;
+
+            switch (_shieldStrength)
+            {
+                case 2:
+                    _ShieldVisualer.GetComponent<Renderer>().material.color = Color.green;
+                    break;
+                case 1:
+                    _ShieldVisualer.GetComponent<Renderer>().material.color = Color.red;
+                    break;
+                case 0:
+                    _isShieldPowerUpActive = false;
+                    _ShieldVisualer.SetActive(false);
+                    break;
+                default:
+                    break;
+            }
             return;
         }
         _lives--;
+
+        Debug.Log("Player lives"+ _lives);
 
         if (_lives == 2)
         {
@@ -228,7 +247,11 @@ public class Player : MonoBehaviour
     public void ShieldPowerUpActive()
     {
         _isShieldPowerUpActive = true;
+        _shieldStrength = 3;
+        _ShieldVisualer.GetComponent<Renderer>().material.color = Color.gray;
         _ShieldVisualer.SetActive(true);
+        
+        
     }
 
     public void AddScore(int points)


### PR DESCRIPTION
Added feature for ShieldStrength
1. Visualize the strength of the shield. This can be done with color changing of the shield -gray, green and red
2 .Allow for 3 hits on the shield to accommodate visualization
When active set the strength to 3 and with color set to gray
As each time player get damage , sheildstrength is subtracted and changing the strength of the shieldVisualser based on the value of shieldStrength.